### PR TITLE
#671 (Walletconnect does not give check mark)

### DIFF
--- a/lib/infrastructure/providers/setup_user_provider/setup_user_view_model.dart
+++ b/lib/infrastructure/providers/setup_user_provider/setup_user_view_model.dart
@@ -296,7 +296,8 @@ class SetupUserViewModel with ChangeNotifier {
           uid = ids.first;
         } else {
           uid = address;
-          socialLinksModel = SocialLinksModel(accountName: 'WalletConnect', userId: uid);
+          //For Don't show mark
+          // socialLinksModel = SocialLinksModel(accountName: 'WalletConnect', userId: uid);
         }
 
         if (uid?.isNotEmpty ?? false) {

--- a/lib/ui/screens/app_settings/app_settings_page.dart
+++ b/lib/ui/screens/app_settings/app_settings_page.dart
@@ -4,7 +4,6 @@ import 'package:app_2i2i/infrastructure/commons/instagram_config.dart';
 import 'package:app_2i2i/infrastructure/commons/utils.dart';
 import 'package:app_2i2i/infrastructure/data_access_layer/accounts/walletconnect_account.dart';
 import 'package:app_2i2i/infrastructure/data_access_layer/repository/instagram_service.dart';
-import 'package:app_2i2i/infrastructure/models/social_links_model.dart';
 import 'package:app_2i2i/ui/commons/custom.dart';
 import 'package:app_2i2i/ui/commons/custom_app_bar.dart';
 import 'package:app_2i2i/ui/screens/app/wait_page.dart';
@@ -495,11 +494,11 @@ class _AppSettingPageState extends ConsumerState<AppSettingPage> with TickerProv
         CustomAlertWidget.loader(true, context, rootNavigator: true);
 
         await account.save(id);
-        var socialLinksModel = SocialLinksModel(accountName: 'WalletConnect', userId: account.address, userName: setupUserViewModel.userInfoModel!.name);
+        // var socialLinksModel = SocialLinksModel(accountName: 'WalletConnect', userId: account.address, userName: setupUserViewModel.userInfoModel!.name);
         await myAccountPageViewModel.updateDBWithNewAccount(account.address, type: 'WC');
         await myAccountPageViewModel.updateAccounts();
         await account.setMainAccount();
-        await setupUserViewModel.signInProcess(userId, socialLinkModel: socialLinksModel);
+        await setupUserViewModel.signInProcess(userId);
 
         CustomAlertWidget.loader(false, context, rootNavigator: true);
 


### PR DESCRIPTION
Issue: since almost every user is expected to connect some walletconnect, it does not constitute a check mark.
check mark is for reputation proven, like social media.

Status: Solved.